### PR TITLE
Fix verbose option in tests and -V option, fix #49

### DIFF
--- a/lib/Documentable/Registry.pm6
+++ b/lib/Documentable/Registry.pm6
@@ -96,7 +96,7 @@ method load (Str :$path --> Positional[Pod::Block::Named]) {
 method process-pod-dir(Str :$dir) {
     # pods to process
     my @pod-files = get-pod-names(:$!topdir, :$dir);
-    say "Processing $dir directory...";
+    say "Processing $dir directory..." if $!verbose;
     my $bar = Bar.new: type => "equals";
     my $length = +@pod-files;
     for @pod-files.kv -> $num, (:key($filename), :value($file)) {
@@ -111,7 +111,7 @@ method process-pod-dir(Str :$dir) {
             self.add-new: :$doc;
         }
     }
-    say "";
+    say "" if $!verbose;
 }
 
 # consulting logic

--- a/t/102-update.t
+++ b/t/102-update.t
@@ -6,7 +6,12 @@ plan *;
 
 subtest 'update option' => {
     # create the cache
-    Documentable::CLI::MAIN('start', :topdir('./t/test-doc') :typegraph-file("t/test-doc/type-graph.txt"));
+    Documentable::CLI::MAIN(
+        'start', 
+        :topdir('./t/test-doc'),
+        :typegraph-file("t/test-doc/type-graph.txt"),
+        :!verbose
+    );
 
     # paths to files that will be changed
     my @paths = <Programs/01-debugging.pod6 /Language/terms.pod6 Native/int.pod6 Type/Map.pod6 HomePage.pod6>.map({"t/test-doc/$_"});
@@ -19,7 +24,7 @@ subtest 'update option' => {
     for @paths Z @files -> ($path, $file) { spurt $path, add-line( $file ) }
 
     # update
-    Documentable::CLI::MAIN('update', :topdir('./t/test-doc'));
+    Documentable::CLI::MAIN('update', :topdir('./t/test-doc'), :!verbose);
 
     # actual test
     for @paths Z @modified-date -> ($path, $date) {
@@ -42,7 +47,7 @@ subtest 'not regenerate all subindexes' => {
     for @paths Z @files -> ($path, $file) { spurt $path, add-line( $file ) }
 
     # update
-    Documentable::CLI::MAIN('update', :topdir('./t/test-doc'));
+    Documentable::CLI::MAIN('update', :topdir('./t/test-doc'), :!verbose);
 
     # actual test
     for @subindexes-path Z @modified-date -> ($path, $date) {


### PR DESCRIPTION
- $verbose option was ignored if some DEBUG calls and lost in some others places.
- '-V' was being executed each time you use Documentable::MAIN(<...>) from
  a test script. I think it has to do something with the signature
  resolution. Checking if -V it's defined solves the problem.

Fix: #49