### PR TITLE
Fix primary name construction

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -45,7 +45,8 @@
     "Documentable::Search": "lib/Documentable/Search.pm6",
     "Documentable::Secondary": "lib/Documentable/Secondary.pm6",
     "Documentable::To::HTML::Wrapper": "lib/Documentable/To/HTML/Wrapper.pm6",
-    "Documentable::Utils::IO": "lib/Documentable/Utils/IO.pm6"
+    "Documentable::Utils::IO": "lib/Documentable/Utils/IO.pm6",
+    "Documentable::Utils::Text": "lib/Documentable/Utils/Text.pm6"
   },
   "resources": [
     "html/images/pencil.svg",

--- a/lib/Documentable/Index.pm6
+++ b/lib/Documentable/Index.pm6
@@ -1,4 +1,5 @@
 use Documentable;
+use Documentable::Utils::Text;
 use Pod::Utilities;
 use Pod::Utilities::Build;
 
@@ -15,11 +16,11 @@ method new(
 
     my $name;
     if $meta.elems > 1 {
-        my $last = textify-guts $meta[*-1];
+        my $last = textify-pod $meta[*-1];
         my $rest = $meta[0..*-2];
         $name = "$last ($rest)";
     } else {
-        $name = textify-guts $meta;
+        $name = textify-pod $meta;
     }
 
     nextwith(

--- a/lib/Documentable/Primary.pm6
+++ b/lib/Documentable/Primary.pm6
@@ -3,6 +3,7 @@ use Documentable::Secondary;
 use Documentable::Index;
 use Documentable::Heading::Grammar;
 use Documentable::Heading::Actions;
+use Documentable::Utils::Text;
 
 use Pod::Utilities;
 use Pod::Utilities::Build;
@@ -121,7 +122,7 @@ class Documentable::Primary is Documentable {
 
             my @meta = $fc.meta[0]:v.flat.cache;
             my $name = (@meta > 1) ?? @meta[1]
-                                !! textify-guts($fc.contents[0]);
+                                !! textify-pod($fc.contents[0], '');
 
             %attr = name       => $name.trim,
                     kind       => Kind::Syntax,
@@ -130,7 +131,7 @@ class Documentable::Primary is Documentable {
 
         } else {
             my $g = Documentable::Heading::Grammar.parse(
-                textify-guts(@header),
+                textify-pod(@header, '').trim,
                 :actions(Documentable::Heading::Actions.new)
             ).actions;
 

--- a/lib/Documentable/Secondary.pm6
+++ b/lib/Documentable/Secondary.pm6
@@ -1,4 +1,5 @@
 use Documentable;
+use Documentable::Utils::Text;
 use Pod::Utilities;
 use Pod::Utilities::Build;
 
@@ -18,7 +19,7 @@ class Documentable::Secondary is Documentable {
     ) {
 
         my $url = "/{$kind.Str.lc}/{good-name($name)}";
-        my $url-in-origin = $origin.url ~ "#" ~textify-guts($pod[0]).trim.subst(/\s+/, '_', :g);
+        my $url-in-origin = $origin.url ~ "#" ~textify-pod($pod[0]).trim.subst(/\s+/, '_', :g);
 
         # normalize the pod
         my $title = "($origin.name()) @subkinds[] $name";

--- a/lib/Documentable/Utils/Text.pm6
+++ b/lib/Documentable/Utils/Text.pm6
@@ -1,0 +1,11 @@
+unit module Documentable::Utils::Text;
+
+#| Converts Lists of Pod::Blocks to String
+multi textify-pod (Any:U        , $?) is export { '' }
+multi textify-pod (Str:D      \v, $?) is export { v }
+multi textify-pod (List:D     \v, $separator = ' ') is export { v».&textify-pod.join($separator) }
+multi textify-pod (Pod::Block \v, $?) is export {
+    # core module
+    use Pod::To::Text;
+    pod2text v;
+}

--- a/t/201-documentable-file.t
+++ b/t/201-documentable-file.t
@@ -1,5 +1,6 @@
 use Documentable;
 use Documentable::Primary;
+use Documentable::Utils::Text;
 use Pod::Load;
 use Pod::Utilities;
 use Pod::Utilities::Build;
@@ -49,6 +50,7 @@ subtest "Scope set correctly" => {
 
     for @definitions -> $name, $str {
       test-scope($name, $str);
+      test-scope-with-textify-pod($name, $str);
     }
 }
 
@@ -128,6 +130,12 @@ sub test-scope($name, $str) {
   is textify-guts(get-def($name).pod),
      $str,
      "Scope detection in $name";
+}
+
+sub test-scope-with-textify-pod($name, $str) {
+  is textify-pod(get-def($name).pod),
+     $str,
+     "Scope detection in $name with textify-pod";
 }
 
 sub test-exception($pod, $msg) {

--- a/t/206-documentable-header.t
+++ b/t/206-documentable-header.t
@@ -1,0 +1,52 @@
+use Documentable;
+use Documentable::Primary;
+use Documentable::Utils::Text;
+use Test;
+
+plan *;
+
+my $pod = $=pod[0];
+my $doc = Documentable::Primary.new(
+    :$pod,
+    :filename("internal")
+);
+
+subtest "Non-trivial header" => {
+    my @names = (
+        2, "foo2, method bar",
+        3, "foo3, blue bar",
+        4, "foo4, method bar",
+        5, "foo5 i j bar",
+        6, "foo6",
+        7, "foo7",
+    );
+
+    for @names -> $content-idx, $name {
+        my %attr = $doc.parse-definition-header(
+            :heading($=pod[0].contents[$content-idx])
+        );
+        is %attr<name>, $name, "name correct";
+    }
+}
+
+=begin pod :kind("Type") :subkind(" ") :category(" ")
+
+=TITLE title
+
+=SUBTITLE subtitle
+
+=head1 method C<foo2>, method C<bar>
+
+=head2 routine   I«C<foo3>», blue bar
+
+=head2 method foo4, method C<bar>
+
+=head2   infix C<foo5>   i       j        C<bar>
+
+=head2 submethod C«foo6»
+
+=head2 variable foo7
+
+=end pod
+
+done-testing;


### PR DESCRIPTION
- with the introduction of Documentable::Utils::Text:textify-pod()
a variant of Pod::Utilities::textify-guts()
  - see https://github.com/antoniogamiz/Pod-Utilities/pull/9/files#diff-0ff387c7e4dec76c01cb77aa4d338ee1R5
- as an example, while processing perl6/doc this prevent the generation
of the document '/routine/(<) , infix ⊂' document in favor of
'/routine/(<), infix ⊂'

Also a version bump of Documentable might be worth considering.